### PR TITLE
Restore the original performance that Rust should have

### DIFF
--- a/bench_runner.py
+++ b/bench_runner.py
@@ -60,17 +60,24 @@ class BenchResult:
             "average": stats.mean(self.times_ms),
         }
 
-def run_cmd(cmd: List[str], cwd: Optional[Path] = None, verbose: bool = False) -> subprocess.CompletedProcess:
+def run_cmd(cmd: List[str], cwd: Optional[Path] = None, verbose: bool = False, env: Optional[dict] = None) -> subprocess.CompletedProcess:
     workdir = str(cwd) if cwd else None
     if verbose:
         prefix = f"[CMD in {workdir}] " if workdir else "[CMD] "
         print(prefix + " ".join(map(str, cmd)), file=sys.stderr)
     return subprocess.run(
-        cmd, cwd=workdir, capture_output=True, text=True, check=False
+        cmd, cwd=workdir, capture_output=True, text=True, check=False, env=env
     )
 
 def ensure_built(program: Program, verbose: bool) -> None:
-    proc = run_cmd(program.build_cmd, cwd=program.workdir, verbose=verbose)
+    # Add RUSTFLAGS for native CPU optimization if building Rust
+    env = None
+    if program.name == "rust":
+        import os
+        env = os.environ.copy()
+        env["RUSTFLAGS"] = "-C target-cpu=native"
+    
+    proc = run_cmd(program.build_cmd, cwd=program.workdir, verbose=verbose, env=env)
     if proc.returncode != 0:
         print(f"[ERROR] Build failed for {program.name}.", file=sys.stderr)
         print("Command:", " ".join(program.build_cmd), file=sys.stderr)

--- a/fft/rs/src/lib.rs
+++ b/fft/rs/src/lib.rs
@@ -63,33 +63,32 @@ pub fn fft(arr: &mut [Complex]) {
             return;
         }
 
-        let mut a0 = Vec::with_capacity(n / 2);
-        let mut a1 = Vec::with_capacity(n / 2);
-
-        for i in 0..n / 2 {
-            a0.push(arr[2 * i]);
-            a1.push(arr[2 * i + 1]);
-        }
+        let mut a0: Vec<Complex> = arr.iter().step_by(2).copied().collect();
+        let mut a1: Vec<Complex> = arr.iter().skip(1).step_by(2).copied().collect();
 
         _fft(&mut a0);
         _fft(&mut a1);
 
         let ang = -2.0 * PI / n as f64;
-        let mut w = Complex::new(1.0, 0.0);
         let wn = Complex::new(ang.cos(), ang.sin());
 
-        for i in 0..n / 2 {
-            let p = a0[i];
-            let q = w * a1[i];
-            arr[i] = p + q;
-            arr[i + n / 2] = p - q;
-            w = w * wn;
-        }
+        // Use split_at_mut to avoid bounds checking and get mutable references to both halves
+        let (first_half, second_half) = arr.split_at_mut(n / 2);
+
+        let mut w = Complex::new(1.0, 0.0);
+        a0.iter()
+            .zip(a1.iter())
+            .zip(first_half.iter_mut())
+            .zip(second_half.iter_mut())
+            .for_each(|(((p, q), first), second)| {
+                let wq = w * *q;
+                *first = *p + wq;
+                *second = *p - wq;
+                w = w * wn;
+            });
     }
 
     _fft(arr);
     let factor = 1.0 / (arr.len() as f64).sqrt();
-    for it in arr {
-        *it = *it * factor;
-    }
+    arr.iter_mut().for_each(|x| *x = *x * factor);
 }

--- a/fft/rs/src/main.rs
+++ b/fft/rs/src/main.rs
@@ -7,14 +7,15 @@ fn round(n: f64) -> f64 {
 }
 
 fn generate_inputs(len: usize) -> Vec<Complex> {
-    let mut res = Vec::with_capacity(len);
-    for i in 0..len {
-        let theta = i as f64 / len as f64 * PI;
-        let re = 1.0 * (10.0 * theta).cos() + 0.5 * (25.0 * theta).cos();
-        let im = 1.0 * (10.0 * theta).sin() + 0.5 * (25.0 * theta).sin();
-        res.push(Complex::new(round(re), round(im)));
-    }
-    res
+    // Use iterator to generate inputs more efficiently
+    (0..len)
+        .map(|i| {
+            let theta = i as f64 / len as f64 * PI;
+            let re = 1.0 * (10.0 * theta).cos() + 0.5 * (25.0 * theta).cos();
+            let im = 1.0 * (10.0 * theta).sin() + 0.5 * (25.0 * theta).sin();
+            Complex::new(round(re), round(im))
+        })
+        .collect()
 }
 
 fn main() {
@@ -26,20 +27,23 @@ fn main() {
     let end = std::time::Instant::now();
 
     if args.len() > 2 {
-        let content = std::fs::read_to_string(args[2].clone()).unwrap();
-        let input = content
+        // Use iterator chain for file parsing and verification
+        let expected_values: Vec<Complex> = std::fs::read_to_string(&args[2])
+            .unwrap()
             .lines()
-            .map(|l| {
-                let (re, im) = l.split_once(',').unwrap();
-                let re = re.parse::<f64>().unwrap();
-                let im = im.parse::<f64>().unwrap();
-                Complex::new(re, im)
+            .map(|line| {
+                let (re_str, im_str) = line.split_once(',').unwrap();
+                Complex::new(re_str.parse().unwrap(), im_str.parse().unwrap())
             })
-            .collect::<Vec<_>>();
-        for (i, signal) in signals.iter().enumerate() {
-            let expected = input[i];
-            assert_eq!(signal, &expected);
-        }
+            .collect();
+
+        // Use iterator for verification
+        signals
+            .iter()
+            .zip(expected_values.iter())
+            .for_each(|(actual, expected)| {
+                assert_eq!(actual, expected);
+            });
     } else {
         println!(
             "execution time: {:.3} ms",


### PR DESCRIPTION
## Description

I only made two changes:
1. Use iterators wherever possible.
2. Compile with `-C target-cpu=native` for better CPU instruction set compatibility.

No third-party libraries were used, and your original code logic was fully preserved.  
As mentioned in #7, the performance bottleneck might be due to the repeated allocation of `Vec`. Potential optimizations could involve using `SmallVec` or a better memory allocator, but these would currently require third-party libraries (`SmallVec` seems to have been merged into the standard library in the latest Rust version).

I merely made the code more conducive to compiler optimizations, and the performance has already surpassed the original. The claim in the video about FFT performance seems a bit exaggerated.

## Effectiveness
The benchmark results for the local 8-core AMD CPU are as follows:

```
> uv run python bench_runner.py
[BUILD] rust ...
[BUILD] moonbit ...
[BUILD] go ...
[RUN] rust n=18
[RUN] moonbit n=18
[RUN] go n=18
[RUN] rust n=20
[RUN] moonbit n=20
[RUN] go n=20
[RUN] rust n=22
[RUN] moonbit n=22
[RUN] go n=22

==========================================================================================
Benchmark Summary (execution time in ms)
==========================================================================================
Program                Input   Runs      Fastest      Slowest       Median      Average
---------------------------------------------------------------------------------------
rust                      18     10    18.568 ms    19.782 ms    19.090 ms    19.139 ms
moonbit                   18     10    18.073 ms    25.513 ms    18.576 ms    19.231 ms
go                        18     10    28.674 ms    31.688 ms    30.523 ms    30.452 ms
---------------------------------------------------------------------------------------
rust                      20     10    81.710 ms    85.640 ms    83.815 ms    83.719 ms
moonbit                   20     10    80.075 ms    87.169 ms    82.528 ms    82.358 ms
go                        20     10   120.267 ms   135.991 ms   121.406 ms   123.445 ms
---------------------------------------------------------------------------------------
rust                      22     10   354.365 ms   396.586 ms   360.565 ms   368.266 ms
moonbit                   22     10   352.787 ms   410.420 ms   361.302 ms   365.658 ms
go                        22     10   505.815 ms   580.287 ms   511.892 ms   524.591 ms
==========================================================================================

[INFO] Saved average line chart to bench_avg.png
```

The corresponding image:
<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/2dd632e3-5380-4dec-b8d2-a01f294aed9a" />


