### PR TITLE
fix: executable for rust not found if custom build.target-dir is set

### DIFF
--- a/bench_runner.py
+++ b/bench_runner.py
@@ -180,7 +180,7 @@ def main():
     rust = Program(
         name="rust",
         workdir=repo_root / "fft" / "rs",
-        build_cmd=["cargo", "build", "--release"],
+        build_cmd=["cargo", "build", "--release", "--target-dir", "target"],
         exe_path=Path("target") / "release" / "main",
     )
     mbt = Program(

--- a/bench_runner.py
+++ b/bench_runner.py
@@ -180,6 +180,7 @@ def main():
     rust = Program(
         name="rust",
         workdir=repo_root / "fft" / "rs",
+        # force set target-dir to avoid custom build.target-dir in user environment
         build_cmd=["cargo", "build", "--release", "--target-dir", "target"],
         exe_path=Path("target") / "release" / "main",
     )


### PR DESCRIPTION
fix issue #18 